### PR TITLE
Fix mobile parallax breaking on section expand

### DIFF
--- a/__tests__/components/ParallaxBackground.test.tsx
+++ b/__tests__/components/ParallaxBackground.test.tsx
@@ -2,6 +2,20 @@ import React from 'react';
 import {render, screen, act} from '@testing-library/react';
 import ParallaxBackground from '../../app/[locale]/components/ParallaxBackground';
 
+// Mock ResizeObserver
+const mockDisconnect = jest.fn();
+const mockObserve = jest.fn();
+let resizeCallback: ResizeObserverCallback;
+class MockResizeObserver {
+  constructor(cb: ResizeObserverCallback) {
+    resizeCallback = cb;
+  }
+  observe = mockObserve;
+  unobserve = jest.fn();
+  disconnect = mockDisconnect;
+}
+(global as any).ResizeObserver = MockResizeObserver;
+
 // Helper: mock window.matchMedia
 function mockMatchMedia(matches: boolean) {
   const listeners: Array<(e: MediaQueryListEvent) => void> = [];
@@ -190,7 +204,36 @@ describe('ParallaxBackground', () => {
       expect(contentDiv).not.toBeNull();
     });
 
-    it('cleans up scroll listener on unmount', () => {
+    it('observes body resize to handle layout shifts from sibling sections', () => {
+      mockObserve.mockClear();
+      render(
+        <ParallaxBackground>
+          <span>Content</span>
+        </ParallaxBackground>
+      );
+      expect(mockObserve).toHaveBeenCalledWith(document.body);
+    });
+
+    it('recalculates background position on body resize', () => {
+      render(
+        <ParallaxBackground>
+          <span>Content</span>
+        </ParallaxBackground>
+      );
+      const bg = screen.getByTestId('parallax-bg');
+      const container = bg.parentElement!;
+      container.getBoundingClientRect = jest.fn().mockReturnValue({top: -300});
+
+      // Simulate a resize (e.g. sibling dropdown expanded)
+      act(() => {
+        resizeCallback([] as any, {} as any);
+      });
+
+      expect(bg.style.transform).toBe('translateY(300px)');
+    });
+
+    it('cleans up scroll listener and ResizeObserver on unmount', () => {
+      mockDisconnect.mockClear();
       const removeSpy = jest.spyOn(window, 'removeEventListener');
       const {unmount} = render(
         <ParallaxBackground>
@@ -199,6 +242,7 @@ describe('ParallaxBackground', () => {
       );
       unmount();
       expect(removeSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+      expect(mockDisconnect).toHaveBeenCalled();
       removeSpy.mockRestore();
     });
 

--- a/app/[locale]/components/ParallaxBackground.tsx
+++ b/app/[locale]/components/ParallaxBackground.tsx
@@ -63,7 +63,17 @@ export default function ParallaxBackground({
 
     window.addEventListener('scroll', handleScroll, {passive: true});
     handleScroll(); // initial position
-    return () => window.removeEventListener('scroll', handleScroll);
+
+    // Also recalculate when content resizes (e.g. dropdown expands in a
+    // sibling section, pushing this one down). Observing document.body
+    // catches any layout shift on the page.
+    const observer = new ResizeObserver(handleScroll);
+    observer.observe(document.body);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      observer.disconnect();
+    };
   }, [isMobile, handleScroll]);
 
   // Desktop: pure CSS parallax via bg-fixed


### PR DESCRIPTION
## Summary
- Fix mobile parallax backgrounds going stale when dropdown sections expand/collapse
- When a dropdown opens in one section, sibling sections shift down but no scroll event fires, leaving their background transforms at the wrong position
- Added a `ResizeObserver` on `document.body` to detect layout changes and recalculate all parallax backgrounds when the page content resizes
- Added tests for ResizeObserver setup, recalculation on resize, and cleanup on unmount

## Test plan
- [ ] Open the site on a mobile device (or devtools mobile viewport)
- [ ] Verify all sections show different slices of the mountain background
- [ ] Expand a dropdown (e.g. Experience) — verify sections below update their background position correctly
- [ ] Collapse the dropdown — verify backgrounds re-adjust
- [ ] Run `npm test` — all 379 tests pass

https://claude.ai/code/session_018MX3u2A35Wo1kcxZw5oWfr