### PR TITLE
feat(ui): dark mode + Paper & Ink token migration (fixes unhighlighted code)

### DIFF
--- a/.debug/000-quick-reference.md
+++ b/.debug/000-quick-reference.md
@@ -1,174 +1,111 @@
-# Quick Reference - Next.js 16 Project
+# Quick Reference — Next.js 16 Blog
 
-**Last Updated**: 2026-01-02
+**Last Updated**: 2026-07-23
 
 ## 🚀 Quick Start
 
 ```bash
-# Development (MUST use --webpack)
-npm run dev
-
-# Build
-npm run build
-
-# Production
-npm start
+nvm use            # Node 24 (required — see below)
+npm install
+npm run dev        # Turbopack dev server
+npm run build      # production build
+npm run start      # serve production build
+npm run lint       # ESLint 10 flat config
+npm run test       # Jest + ts-jest
 ```
 
-## ⚠️ Critical Information
+## ⚠️ Must-Know
 
-### Must-Know Issues
-1. **Always use webpack mode** - Turbopack breaks i18n translations
-2. **React 19 types** - Use `React.JSX.Element` not `JSX.Element`
-3. **Four languages** - en, fr, de, es (test all when adding translations)
+1. **App Router + next-intl + Turbopack.** Everything is under `app/[locale]/`. The dev
+   script is `next dev --turbopack`. There is no Pages Router, no `next-translate`, and no
+   `--webpack` flag. Any older note claiming otherwise predates the `474b44c` migration.
+2. **Node 24.** ESLint 10 crashes on Node < 20.19 (`util.styleText is not a function`) and
+   `@testing-library/jest-dom` 7 needs Node ≥ 22. `nvm use` reads `.nvmrc` (= 24).
+3. **TypeScript 5.x, never 7.x.** The Go-port compiler ships no compiler API and breaks
+   `next build` + `@typescript-eslint`. `renovate.json` caps it at `<7`.
+4. **React 19 types** — `React.JSX.Element`, not `JSX.Element`.
+5. **Four locales** — en, fr, de, es. Add every user-facing string to all four
+   `locales/*/common.json`.
+6. **Style with palette tokens**, not stock Tailwind greys/blues — see Styling below.
 
 ## 📁 File Organization
 
 ```
 nextjs-blog/
-├── .debug/              # Debug docs (Git: ✅ Production: ❌)
-│   ├── 001-upgrade-notes-2026-01-02.md
-│   ├── 002-i18n-fix-2026-01-02.md
-│   └── README.md
-├── .github/
-│   └── copilot-instructions.md
-├── pages/               # Next.js pages (Pages Router)
-├── components/          # React components
-├── locales/            # Translation files
-│   ├── en/common.json
-│   ├── fr/common.json
-│   ├── de/common.json
-│   └── es/common.json
-├── lib/                # Utility functions
-└── styles/             # CSS styles
+├── app/[locale]/           # App Router — pages + components/
+│   ├── components/         # ~40 React components (CodeBlock, TripCard, …)
+│   ├── posts/<slug>/       # article bodies authored as TSX, per locale
+│   ├── layout.tsx, page.tsx
+│   ├── sitemap.ts, robots.ts
+├── lib/
+│   ├── registry.ts         # THE content model (typed, per-locale) — not markdown
+│   ├── drafts.ts           # draftsVisible flag
+│   ├── draft-post-meta.ts  # draft listing strings (kept out of locale bundles)
+│   └── i18n/               # routing.ts, request.ts, navigation.ts (next-intl v4)
+├── locales/{en,fr,de,es}/common.json
+├── styles/globals.css      # Paper & Ink tokens + dark mode + shiki mapping
+├── proxy.ts                # next-intl middleware + draft 404 gating
+├── next.config.ts          # createNextIntlPlugin('./lib/i18n/request.ts')
+└── .debug/                 # these docs (gitignored; force-added)
 ```
 
-## 🔧 Common Commands
-
-```bash
-# Development
-npm run dev              # Start dev server with webpack
-
-# Building
-npm run build            # Production build with webpack
-
-# Dependencies
-npm install              # Install dependencies
-npm audit fix            # Fix security issues
-
-# Utilities
-npx update-browserslist-db@latest  # Update browser data
-```
-
-## 🐛 Known Issues & Solutions
-
-| Issue | Solution | Reference |
-|-------|----------|-----------|
-| Translations not working | Use `npm run dev` (has --webpack flag) | 002-i18n-fix |
-| JSX.Element type error | Use `React.JSX.Element` | 001-upgrade-notes |
-| Hydration mismatch | Check date/time formatting | agent.md |
-
-## 📝 Translation Usage
+## 🌍 Translations
 
 ```tsx
-import useTranslation from 'next-translate/useTranslation'
+// Server component
+import {getTranslations} from 'next-intl/server';
+const t = await getTranslations({locale});
 
-function MyComponent() {
-  const { t } = useTranslation('common')
-  
-  return <h1>{t('title')}</h1>
-}
+// Client component
+import {useTranslations} from 'next-intl';
+const t = useTranslations();
+
+<h1>{t('some.key')}</h1>   // add `some.key` to all four common.json files
 ```
 
-## 🔑 Key Configuration
+## 🧭 Content
 
-### package.json scripts
-```json
-"dev": "next dev --webpack",      // ⚠️ --webpack is critical
-"build": "next build --webpack"   // ⚠️ --webpack is critical
-```
+Content lives in `lib/registry.ts` — a typed `registry: Record<category, ContentItem[]>`
+with per-locale `title`/`description` objects. Use `getSortedItems(category, locale)` for
+listings. Draft posts (`draft: true`) are collected into `draftPostIds` and 404'd by
+`proxy.ts` unless `draftsVisible` (dev, or `SHOW_DRAFTS=1`).
 
-### tsconfig.json
-```json
-"moduleResolution": "bundler",    // Required for Next.js 16
-"target": "ES2017"                // Better performance
-```
+## 🎨 Styling — Paper & Ink
 
-### next.config.js
-```js
-turbopack: {},                    // Explicit config
-webpack: (config) => { ... }      // Keep for compatibility
-```
+`styles/globals.css` (Tailwind v4, CSS-first — no `tailwind.config`; root
+`tailwindcss-config.js` is dead). Ten colour tokens in `:root` flip in a
+`@media (prefers-color-scheme: dark)` block. An `@theme inline` block exposes them as
+utilities — **use these, not stock Tailwind colours**:
 
-## 📚 Documentation Priority
+| Use | Token utility |
+|-----|---------------|
+| Body / strong text | `text-ink` |
+| Secondary text | `text-ink-soft` |
+| Muted / meta | `text-ink-muted` |
+| Card surface | `bg-paper` |
+| Subtle fill / track | `bg-bg-alt` |
+| Hairlines | `border-rule` / `divide-rule` |
+| Brand / links / CTAs | `text-accent` / `bg-accent` / `text-accent-fg` |
+| Soft accent chip | `bg-accent-soft` |
 
-1. `.debug/` directory (latest file first)
-2. `agent.md` (coding standards)
-3. Configuration files
-4. External docs
+No `dark:` variants for these (they flip already). Code blocks: `CodeBlock.tsx` uses shiki
+with `defaultColor: false`; `globals.css` maps `--shiki-light` / `--shiki-dark`. Categorical
+data colours (SkillBar/RadarChart series, success-green, error-red) intentionally stay as
+explicit palette hues.
 
-## 🎯 Adding New Debug Files
+## 📊 Project Status (2026-07-23)
 
-```bash
-# Pattern: NNN-description-YYYY-MM-DD.md
-# Example: 003-new-feature-2026-01-15.md
+| Package | Version |
+|---------|---------|
+| Next.js | 16.2.x |
+| React | 19.2.x |
+| next-intl | 4.13.x |
+| TypeScript | 5.9.x (capped `<7`) |
+| ESLint | 10.x (flat config) |
+| Tailwind | 4.3.x |
+| Node | 24 (Active LTS) |
 
-# Steps:
-1. Create file in .debug/
-2. Update .debug/README.md
-3. Add to File Index table
-4. Commit to Git
-```
+## 🎯 Adding a Debug File
 
-## 🔍 Troubleshooting Checklist
-
-- [ ] Are you using `npm run dev` (not `next dev` directly)?
-- [ ] Is webpack mode active? (check terminal output)
-- [ ] Are translations in all 4 languages? (en, fr, de, es)
-- [ ] Did you check `.debug/` for similar issues?
-- [ ] Is TypeScript configured correctly? (moduleResolution: bundler)
-
-## 📞 Get Help
-
-1. Check `.debug/README.md` for relevant documentation
-2. Review `agent.md` for coding patterns
-3. Check latest `.debug/NNN-*.md` file for recent changes
-4. Verify configuration in upgrade notes
-
-## 🎨 Code Style Quick Reference
-
-```tsx
-// ✅ Good
-interface UserProps {
-  name: string
-}
-
-export function UserProfile({ name }: UserProps): React.JSX.Element {
-  return <div>{name}</div>
-}
-
-// ❌ Bad (old React 18 pattern)
-export function UserProfile({ name }: UserProps): JSX.Element {
-  return <div>{name}</div>
-}
-```
-
-## 🌍 Supported Locales
-
-- `en` - English (default)
-- `fr` - French (Français)
-- `de` - German (Deutsch)
-- `es` - Spanish (Español)
-
-## 📊 Project Status
-
-| Component | Version | Status |
-|-----------|---------|--------|
-| Next.js | 16.1.1 | ✅ Latest |
-| React | 19.2.3 | ✅ Latest |
-| TypeScript | 5.3.3 | ✅ Current |
-| next-translate | 2.6.2 | ⚠️ Webpack only |
-
----
-
-**Quick Tip**: When in doubt, check `.debug/README.md` first!
+Pattern `NNN-description-YYYY-MM-DD.md`. Create it, add a row to `.debug/README.md`, then
+`git add -f` it (`.debug/*` is gitignored but the notes are tracked).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,58 +5,84 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm run dev      # Start dev server (--webpack flag included automatically)
-npm run build    # Production build (--webpack flag included automatically)
-npm run lint     # Lint the project
+npm run dev            # Start dev server (Turbopack)
+npm run build          # Production build
+npm run start          # Serve the production build
+npm run lint           # ESLint (flat config) over app/ and lib/
+npm run test           # Jest + ts-jest
+npm run test:coverage  # Jest with coverage
 ```
 
-**Critical**: Must use webpack mode — `next-translate-plugin` does not support Turbopack. The `--webpack` flag is already baked into the npm scripts; never switch to Turbopack.
+**Runtime**: Node 24 (see `.nvmrc` / `engines`). ESLint 10 will not run on Node < 20.19,
+and `@testing-library/jest-dom` 7 needs Node ≥ 22 — run `nvm use` before installing.
 
 ## Architecture
 
-**Pages Router** (not App Router). Next.js 16 + React 19 + TypeScript.
+**App Router** — Next.js 16 + React 19 + TypeScript, everything under `app/[locale]/`.
+Rendered with **Turbopack** (`next dev --turbopack`); there is no webpack flag and no
+`next-translate`. (Any older doc mentioning Pages Router, `next-translate`, `i18n.json`,
+or a `--webpack` requirement is stale — the App Router migration landed in `474b44c`.)
 
-### Content System
+### Content model — `lib/registry.ts`
 
-All content is stored as Markdown files organized by content type and locale:
+Content is **not** Markdown files. It is a single typed registry: `lib/registry.ts` exports
+a `registry: Record<string, ContentItem[]>` keyed by category (`experience`, `education`,
+`posts`, `projects`, …). Each `ContentItem` carries per-locale `title`/`description` objects
+(`{en, fr, de, es}`), a `date`, and category-specific fields. Helpers:
 
-```
-posts/[slug]/index.md          # English (default)
-posts/[slug]/index.fr.md       # French
-posts/[slug]/index.de.md       # German
-posts/[slug]/index.es.md       # Spanish
-```
+- `getSortedItems(category, locale)` — localized, published items for listings
+- `draftPostIds` — slugs flagged `draft: true`, consumed by the proxy (below)
 
-Same pattern applies to: `experience/`, `education/`, `hobbies/`, `about_me/`, `skills/`.
+Long-form article bodies (the `/posts/<slug>` pages) are authored as TSX in
+`app/[locale]/posts/<slug>/page.tsx`, one `<CodeBlock>`/section per locale.
 
-Each Markdown file uses gray-matter frontmatter with at minimum `date` and `title` fields.
+### Internationalization — `next-intl` v4
 
-### Data Layer (`lib/`)
+Config lives in `lib/i18n/`:
+- `routing.ts` — `defineRouting({locales: ['en','fr','de','es'], defaultLocale: 'en', localePrefix: 'as-needed'})`
+- `request.ts` — `getRequestConfig` loading `locales/[locale]/common.json`; wired via
+  `createNextIntlPlugin('./lib/i18n/request.ts')` in `next.config.ts`
+- `navigation.ts` — locale-aware `Link`, `redirect`, `usePathname`, `useRouter`
 
-Each content type has a corresponding lib file (`posts.ts`, `exp.ts`, `educ.ts`, `hob.ts`, `info.ts`, `soft.ts`) with the same three functions:
-- `getSorted*Data(locale)` — lists all items with metadata, used in `getStaticProps`
-- `getAll*Ids(locales)` — generates static paths for `getStaticPaths`
-- `get*Data(id, locale)` — loads and renders a single item's Markdown to HTML
+In **server components**: `const t = await getTranslations({locale})`.
+In **client components**: `const t = useTranslations()` from `next-intl`.
+When adding any user-facing string, add the key to **all four** `locales/*/common.json`.
 
-The `defaultLocale` is imported from `i18n.js`. For the default locale (`en`), the file is `index.md`; for others it's `index.[locale].md`.
+### Draft gating — `proxy.ts`
 
-### Internationalization
+`proxy.ts` (repo root; Next 16's renamed middleware) composes next-intl's middleware with
+draft blocking: requests to a `draft: true` post are rewritten so Next returns a real 404
+with the correct status. Drafts are visible in `npm run dev` and when `SHOW_DRAFTS=1`, and
+hidden everywhere else (see `lib/drafts.ts`).
 
-`next-translate` is used (not `next-i18next`). Configuration in `i18n.json`:
-- Supported locales: `en`, `fr`, `de`, `es` — `en` is the default
-- All locales use a single namespace: `common`
-- Translation files: `locales/[lang]/common.json`
+### Styling — Paper & Ink design system
 
-In components, use `useTranslation('common')` from `next-translate/useTranslation`. When adding any user-facing string, add the translation key to all 4 locale files.
+Global CSS is `styles/globals.css` (Tailwind v4, CSS-first — there is no
+`tailwind.config`; the 22 KB `tailwindcss-config.js` at the root is dead). Colour is a
+locked token palette in `:root` (`--bg`, `--ink`, `--ink-soft`, `--ink-muted`, `--rule`,
+`--accent`, `--paper`, …), with a `@media (prefers-color-scheme: dark)` block that flips
+those ten tokens for dark mode.
 
-### Key TypeScript Constraint
+An `@theme inline` block exposes the tokens as Tailwind utilities. **Prefer these over
+stock Tailwind colours** so components track the palette and dark mode automatically:
+`text-ink` / `text-ink-soft` / `text-ink-muted`, `bg-paper` / `bg-bg-alt`, `border-rule` /
+`divide-rule`, `bg-accent` / `text-accent` / `text-accent-fg` / `bg-accent-soft`. Do **not**
+reintroduce `bg-gray-*` / `text-blue-*` for chrome, and do not add `dark:` variants for
+these — the tokens already flip. Genuinely categorical data colours (the SkillBar/RadarChart
+series, success-green, error-red) are the one exception and stay as explicit palette hues.
 
-Use `React.JSX.Element` (not `JSX.Element`) — this is required due to React 19 type changes.
+### Key TypeScript constraints
 
-`tsconfig.json` must use `moduleResolution: "bundler"`.
+- Use `React.JSX.Element`, not `JSX.Element` (React 19 type change).
+- `tsconfig.json` uses `moduleResolution: "bundler"`.
+- Stay on TypeScript **5.x**, not 7.x — the Go-port compiler breaks `next build`'s
+  type-check and `@typescript-eslint`. `renovate.json` enforces the `<7` cap; see
+  `.debug/006-dependency-upgrade-2026-07-22.md`.
 
 ## Debug Documentation
 
-Significant debugging sessions are tracked in `.debug/NNN-description-YYYY-MM-DD.md` files. When adding a new debug file:
-1. Use the next available sequence number
-2. Update `.debug/README.md` with a new entry in the File Index table
+Significant sessions are tracked in `.debug/NNN-description-YYYY-MM-DD.md`. When adding one:
+1. Use the next sequence number.
+2. Add a row to the File Index table in `.debug/README.md`.
+
+(`.debug/*` is gitignored but the files are force-added — `git add -f` a new note.)

--- a/__tests__/components/CategoryNav.test.tsx
+++ b/__tests__/components/CategoryNav.test.tsx
@@ -45,40 +45,40 @@ describe('CategoryNav', () => {
     expect(links[2]).toHaveAttribute('href', '/skills/nodejs');
   });
 
-  it('applies bg-blue-600 class to active item', () => {
+  it('applies bg-accent class to active item', () => {
     mockUsePathname.mockReturnValue('/skills/react');
     render(<CategoryNav items={mockItems} baseDir="skills" />);
 
     const reactLink = screen.getByText('React');
-    expect(reactLink).toHaveClass('bg-blue-600');
-    expect(reactLink).toHaveClass('text-white');
+    expect(reactLink).toHaveClass('bg-accent');
+    expect(reactLink).toHaveClass('text-accent-fg');
   });
 
-  it('applies bg-gray-100 class to inactive items', () => {
+  it('applies bg-bg-alt class to inactive items', () => {
     mockUsePathname.mockReturnValue('/skills/react');
     render(<CategoryNav items={mockItems} baseDir="skills" />);
 
     const tsLink = screen.getByText('TypeScript');
     const nodeLink = screen.getByText('Node.js');
 
-    expect(tsLink).toHaveClass('bg-gray-100');
-    expect(nodeLink).toHaveClass('bg-gray-100');
+    expect(tsLink).toHaveClass('bg-bg-alt');
+    expect(nodeLink).toHaveClass('bg-bg-alt');
   });
 
-  it('inactive items do not have bg-blue-600', () => {
+  it('inactive items do not have bg-accent', () => {
     mockUsePathname.mockReturnValue('/skills/react');
     render(<CategoryNav items={mockItems} baseDir="skills" />);
 
     const tsLink = screen.getByText('TypeScript');
-    expect(tsLink).not.toHaveClass('bg-blue-600');
+    expect(tsLink).not.toHaveClass('bg-accent');
   });
 
-  it('active item does not have bg-gray-100', () => {
+  it('active item does not have bg-bg-alt', () => {
     mockUsePathname.mockReturnValue('/skills/react');
     render(<CategoryNav items={mockItems} baseDir="skills" />);
 
     const reactLink = screen.getByText('React');
-    expect(reactLink).not.toHaveClass('bg-gray-100');
+    expect(reactLink).not.toHaveClass('bg-bg-alt');
   });
 
   it('matches active item based on pathname ending', () => {
@@ -87,10 +87,10 @@ describe('CategoryNav', () => {
     render(<CategoryNav items={mockItems} baseDir="skills" />);
 
     const tsLink = screen.getByText('TypeScript');
-    expect(tsLink).toHaveClass('bg-blue-600');
+    expect(tsLink).toHaveClass('bg-accent');
 
     const reactLink = screen.getByText('React');
-    expect(reactLink).toHaveClass('bg-gray-100');
+    expect(reactLink).toHaveClass('bg-bg-alt');
   });
 
   it('no items are active when pathname does not match any item', () => {
@@ -99,8 +99,8 @@ describe('CategoryNav', () => {
 
     const links = screen.getAllByRole('link');
     links.forEach((link) => {
-      expect(link).toHaveClass('bg-gray-100');
-      expect(link).not.toHaveClass('bg-blue-600');
+      expect(link).toHaveClass('bg-bg-alt');
+      expect(link).not.toHaveClass('bg-accent');
     });
   });
 
@@ -147,6 +147,6 @@ describe('CategoryNav', () => {
     render(<CategoryNav items={[{id: 'only', label: 'Only Item'}]} baseDir="skills" />);
 
     const link = screen.getByText('Only Item');
-    expect(link).toHaveClass('bg-blue-600');
+    expect(link).toHaveClass('bg-accent');
   });
 });

--- a/__tests__/components/CodeBlock.test.tsx
+++ b/__tests__/components/CodeBlock.test.tsx
@@ -72,7 +72,7 @@ describe('CopyButton', () => {
 
   it('has hover styling classes', () => {
     render(<CopyButton code="x" />);
-    expect(screen.getByRole('button')).toHaveClass('hover:bg-gray-200');
+    expect(screen.getByRole('button')).toHaveClass('hover:bg-bg-alt');
   });
 
   it('handles empty code string', async () => {

--- a/__tests__/components/DurationBars.test.tsx
+++ b/__tests__/components/DurationBars.test.tsx
@@ -88,7 +88,7 @@ describe('DurationBars', () => {
 
   it('uses blue color by default', () => {
     const {container} = render(<DurationBars items={mockItems} />);
-    const bar = container.querySelector('.bg-blue-500');
+    const bar = container.querySelector('.bg-accent');
     expect(bar).toBeInTheDocument();
   });
 

--- a/__tests__/components/ReadingTime.test.tsx
+++ b/__tests__/components/ReadingTime.test.tsx
@@ -39,6 +39,6 @@ describe('ReadingTime', () => {
   it('has correct styling classes', () => {
     render(<ReadingTime minutes={3} />);
     const span = screen.getByText('3 min read').closest('span');
-    expect(span).toHaveClass('text-sm', 'text-gray-500');
+    expect(span).toHaveClass('text-sm', 'text-ink-muted');
   });
 });

--- a/__tests__/components/ScrollToTop.test.tsx
+++ b/__tests__/components/ScrollToTop.test.tsx
@@ -138,8 +138,8 @@ describe('ScrollToTop component', () => {
   it('has correct styling classes', () => {
     render(<ScrollToTop />);
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-blue-600');
-    expect(button).toHaveClass('text-white');
+    expect(button).toHaveClass('bg-accent');
+    expect(button).toHaveClass('text-accent-fg');
     expect(button).toHaveClass('rounded-full');
     expect(button).toHaveClass('shadow-lg');
   });

--- a/__tests__/components/SkillBar.test.tsx
+++ b/__tests__/components/SkillBar.test.tsx
@@ -156,6 +156,6 @@ describe('SkillBar', () => {
     expect(container.querySelector('.space-y-3')).toBeInTheDocument();
     expect(screen.getByText('Python')).toBeInTheDocument();
     expect(screen.getByText('70%')).toBeInTheDocument();
-    expect(container.querySelector('.bg-gray-200')).toBeInTheDocument();
+    expect(container.querySelector('.bg-bg-alt')).toBeInTheDocument();
   });
 });

--- a/__tests__/components/Timeline.test.tsx
+++ b/__tests__/components/Timeline.test.tsx
@@ -131,7 +131,7 @@ describe('Timeline', () => {
 
   it('renders timeline dots for each entry', () => {
     const {container} = render(<Timeline entries={mockEntries} />);
-    const dots = container.querySelectorAll('.rounded-full.bg-blue-500');
+    const dots = container.querySelectorAll('.rounded-full.bg-accent');
     expect(dots).toHaveLength(3);
   });
 
@@ -163,7 +163,7 @@ describe('Timeline', () => {
 
   it('renders the center line', () => {
     const {container} = render(<Timeline entries={mockEntries} />);
-    expect(container.querySelector('.bg-gray-300')).toBeInTheDocument();
+    expect(container.querySelector('.bg-bg-alt')).toBeInTheDocument();
   });
 
   it('handles single entry', () => {

--- a/app/[locale]/about_me/infos/page.tsx
+++ b/app/[locale]/about_me/infos/page.tsx
@@ -40,13 +40,13 @@ export default async function InfosPage({params}: {params: Promise<{locale: stri
         <p>{t.intro}</p>
         <ul className="list-disc pl-6 mt-2 space-y-1">
           <li>
-            email : <a href="mailto:alienard.dev@gmail.com" className="text-blue-600 hover:underline">alienard.dev@gmail.com</a>
+            email : <a href="mailto:alienard.dev@gmail.com" className="text-accent hover:underline">alienard.dev@gmail.com</a>
           </li>
           <li>
-            <a href="https://lienardale.github.io/markdown-cv/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">CV</a>
+            <a href="https://lienardale.github.io/markdown-cv/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">CV</a>
           </li>
           <li>
-            <a href="https://www.linkedin.com/in/alienard/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="https://www.linkedin.com/in/alienard/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">LinkedIn</a>
           </li>
         </ul>
 

--- a/app/[locale]/components/CVPreview.tsx
+++ b/app/[locale]/components/CVPreview.tsx
@@ -10,7 +10,7 @@ export default async function CVPreview({url, locale}: Props) {
 
   return (
     <div data-testid="cv-preview">
-      <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+      <div className="border border-rule rounded-lg overflow-hidden">
         <iframe
           src={url}
           title="CV"
@@ -24,7 +24,7 @@ export default async function CVPreview({url, locale}: Props) {
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 px-4 rounded-lg transition-colors duration-200"
+          className="inline-flex items-center gap-2 bg-accent hover:opacity-90 text-accent-fg font-medium py-2.5 px-4 rounded-lg transition-colors duration-200"
           data-testid="cv-open-button"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/app/[locale]/components/CategoryNav.tsx
+++ b/app/[locale]/components/CategoryNav.tsx
@@ -9,7 +9,7 @@ export default function CategoryNav({items, baseDir}: {items: NavItem[]; baseDir
   const pathname = usePathname();
 
   return (
-    <nav className="flex flex-wrap gap-2 mb-6 pb-4 border-b border-gray-200 dark:border-gray-700">
+    <nav className="flex flex-wrap gap-2 mb-6 pb-4 border-b border-rule">
       {items.map((item) => {
         const href = `/${baseDir}/${item.id}`;
         const isActive = pathname.endsWith(`/${item.id}`);
@@ -20,8 +20,8 @@ export default function CategoryNav({items, baseDir}: {items: NavItem[]; baseDir
             href={href}
             className={`px-3 py-1.5 rounded-full text-sm transition-colors ${
               isActive
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                ? 'bg-accent text-accent-fg'
+                : 'bg-bg-alt text-ink-soft hover:bg-bg-alt'
             }`}
           >
             {item.label}

--- a/app/[locale]/components/CodeBlock.tsx
+++ b/app/[locale]/components/CodeBlock.tsx
@@ -18,10 +18,10 @@ export default async function CodeBlock({code, lang, filename}: Props) {
   });
 
   return (
-    <div className="my-6 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
+    <div className="my-6 rounded-lg overflow-hidden border border-rule">
       {filename && (
-        <div className="flex items-center justify-between px-4 py-2 bg-gray-100 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-          <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">{filename}</span>
+        <div className="flex items-center justify-between px-4 py-2 bg-bg-alt border-b border-rule">
+          <span className="text-xs text-ink-muted font-mono">{filename}</span>
           <CopyButton code={code} />
         </div>
       )}

--- a/app/[locale]/components/ContactForm.tsx
+++ b/app/[locale]/components/ContactForm.tsx
@@ -45,7 +45,7 @@ export default function ContactForm() {
       >
         <svg
           viewBox="0 0 64 48"
-          className="w-20 h-16 text-blue-500 dark:text-blue-400"
+          className="w-20 h-16 text-accent"
           data-testid="envelope-icon"
         >
           {/* Envelope body */}
@@ -102,7 +102,7 @@ export default function ContactForm() {
               name="name"
               type="text"
               required
-              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-lg border border-rule bg-paper px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent"
             />
           </div>
 
@@ -115,7 +115,7 @@ export default function ContactForm() {
               name="email"
               type="email"
               required
-              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-lg border border-rule bg-paper px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent"
             />
           </div>
 
@@ -128,7 +128,7 @@ export default function ContactForm() {
               name="message"
               required
               rows={4}
-              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              className="w-full rounded-lg border border-rule bg-paper px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent resize-none"
             />
           </div>
 
@@ -139,7 +139,7 @@ export default function ContactForm() {
           <button
             type="submit"
             disabled={status === 'sending'}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white font-medium py-2.5 px-4 rounded-lg transition-colors duration-200"
+            className="w-full bg-accent hover:opacity-90 disabled:opacity-50 text-accent-fg font-medium py-2.5 px-4 rounded-lg transition-colors duration-200"
           >
             {status === 'sending' ? t('contact_sending') : t('contact_send')}
           </button>

--- a/app/[locale]/components/CopyButton.tsx
+++ b/app/[locale]/components/CopyButton.tsx
@@ -15,13 +15,13 @@ export default function CopyButton({code}: {code: string}) {
   return (
     <button
       onClick={handleCopy}
-      className="p-1.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+      className="p-1.5 rounded hover:bg-bg-alt transition-colors"
       aria-label={copied ? 'Copied' : 'Copy code'}
     >
       {copied ? (
         <CheckIcon className="h-4 w-4 text-green-500" />
       ) : (
-        <ClipboardIcon className="h-4 w-4 text-gray-400" />
+        <ClipboardIcon className="h-4 w-4 text-ink-muted" />
       )}
     </button>
   );

--- a/app/[locale]/components/DurationBars.tsx
+++ b/app/[locale]/components/DurationBars.tsx
@@ -59,11 +59,11 @@ export default function DurationBars({items, color = 'blue'}: Props) {
 
   const barColor = color === 'green'
     ? 'bg-green-500 dark:bg-green-400'
-    : 'bg-blue-500 dark:bg-blue-400';
+    : 'bg-accent';
 
   const bgColor = color === 'green'
     ? 'bg-green-100 dark:bg-green-900/30'
-    : 'bg-blue-100 dark:bg-blue-900/30';
+    : 'bg-accent-soft';
 
   return (
     <div ref={containerRef} className="space-y-3" data-testid="duration-bars">
@@ -72,8 +72,8 @@ export default function DurationBars({items, color = 'blue'}: Props) {
         return (
           <div key={item.title}>
             <div className="flex justify-between text-sm mb-1">
-              <span className="font-medium text-gray-800 dark:text-gray-200">{item.title}</span>
-              <span className="text-gray-500 dark:text-gray-400">
+              <span className="font-medium text-ink">{item.title}</span>
+              <span className="text-ink-muted">
                 {item.startDate} — {item.endDate} ({formatDuration(item.months)})
               </span>
             </div>

--- a/app/[locale]/components/FlipCard.tsx
+++ b/app/[locale]/components/FlipCard.tsx
@@ -32,11 +32,11 @@ export default function FlipCard({front, back}: Props) {
         data-testid="flip-inner"
       >
         {/* Front */}
-        <div className="absolute inset-0 [backface-visibility:hidden] flex items-center justify-center p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+        <div className="absolute inset-0 [backface-visibility:hidden] flex items-center justify-center p-4 rounded-lg border border-rule bg-paper">
           {front}
         </div>
         {/* Back */}
-        <div className="absolute inset-0 [backface-visibility:hidden] [transform:rotateY(180deg)] flex items-center justify-center p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-blue-50 dark:bg-gray-900">
+        <div className="absolute inset-0 [backface-visibility:hidden] [transform:rotateY(180deg)] flex items-center justify-center p-4 rounded-lg border border-rule bg-accent-soft">
           {back}
         </div>
       </div>

--- a/app/[locale]/components/LanguageSwitcher.tsx
+++ b/app/[locale]/components/LanguageSwitcher.tsx
@@ -23,7 +23,7 @@ export default function LanguageSwitcher() {
     <Menu as="div" className="relative inline-block text-left">
       <Menu.Button
         data-dropdown-placement="bottom"
-        className="inline-flex w-full m-1 justify-center rounded-md bg-white dark:bg-gray-800 shadow-lg ring-1 ring-black ring-opacity-5 bg-opacity-80 dark:bg-opacity-80 px-4 py-2 text-xlg text-blue-900 dark:text-blue-300 hover:bg-opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75"
+        className="inline-flex w-full m-1 justify-center rounded-md bg-paper shadow-lg ring-1 ring-black ring-opacity-5 bg-opacity-80 px-4 py-2 text-xlg text-accent hover:bg-opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75"
       >
         {t('trad_button')}
         <ChevronDownIcon
@@ -40,13 +40,13 @@ export default function LanguageSwitcher() {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 mt-2 origin-top-right divide-y divide-blue-100 dark:divide-gray-700 rounded-md bg-white dark:bg-gray-800 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <Menu.Items className="absolute right-0 mt-2 origin-top-right divide-y divide-rule rounded-md bg-paper shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
           <ul className="list-none p-0 m-0">
             {languages.map(({locale: loc, title}) => (
               <Menu.Item key={loc}>
                 <button
                   onClick={() => router.replace(pathname, {locale: loc})}
-                  className="text-blue-900 dark:text-blue-300 group flex w-full items-center rounded-md px-5 py-2 text-sm m-1 hover:bg-blue-500 hover:text-black dark:hover:text-white"
+                  className="text-accent group flex w-full items-center rounded-md px-5 py-2 text-sm m-1 hover:bg-accent hover:text-accent-fg"
                 >
                   {title}
                 </button>

--- a/app/[locale]/components/ProjectCard.tsx
+++ b/app/[locale]/components/ProjectCard.tsx
@@ -10,9 +10,9 @@ type Project = {
 
 export default function ProjectCard({project}: {project: Project}) {
   return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-5 transition-shadow duration-200 hover:shadow-lg dark:hover:shadow-gray-900/40">
+    <div className="border border-rule rounded-lg p-5 transition-shadow duration-200 hover:shadow-lg">
       {project.image ? (
-        <div className="-m-5 mb-3 overflow-hidden rounded-t-lg border-b border-gray-200 dark:border-gray-700">
+        <div className="-m-5 mb-3 overflow-hidden rounded-t-lg border-b border-rule">
           <img
             src={project.image}
             alt={`${project.name} screenshot`}
@@ -29,7 +29,7 @@ export default function ProjectCard({project}: {project: Project}) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`${project.name} on GitHub`}
-            className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+            className="text-ink-muted hover:text-ink"
           >
             <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.08-.74.08-.73.08-.73 1.2.08 1.84 1.23 1.84 1.23 1.07 1.83 2.81 1.3 3.5 1 .1-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.12-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6.02 0c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.25 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.82.58A12.01 12.01 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
@@ -41,7 +41,7 @@ export default function ProjectCard({project}: {project: Project}) {
               target="_blank"
               rel="noopener noreferrer"
               aria-label={`${project.name} live site`}
-              className="text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+              className="text-ink-muted hover:text-accent"
             >
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
@@ -52,14 +52,14 @@ export default function ProjectCard({project}: {project: Project}) {
       </div>
 
       {/* Description */}
-      <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">{project.description}</p>
+      <p className="text-sm text-ink-soft mb-3">{project.description}</p>
 
       {/* Tech badges */}
       <div className="flex flex-wrap gap-1.5 mb-3">
         {project.tech.map((t) => (
           <span
             key={t}
-            className="bg-gray-100 dark:bg-gray-800 text-xs px-2 py-0.5 rounded-full text-gray-700 dark:text-gray-300"
+            className="bg-bg-alt text-xs px-2 py-0.5 rounded-full text-ink-soft"
           >
             {t}
           </span>
@@ -67,7 +67,7 @@ export default function ProjectCard({project}: {project: Project}) {
       </div>
 
       {/* Stats */}
-      <div className="flex gap-4 text-xs text-gray-500 dark:text-gray-400">
+      <div className="flex gap-4 text-xs text-ink-muted">
         <span data-testid="stat-contributors">
           <svg className="w-3.5 h-3.5 inline mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />

--- a/app/[locale]/components/RadarChart.tsx
+++ b/app/[locale]/components/RadarChart.tsx
@@ -74,7 +74,7 @@ export default function RadarChart({skills}: {skills: Skill[]}) {
           points={polygonPoints(count, (level / 100) * RADIUS)}
           fill="none"
           stroke="currentColor"
-          className="text-gray-300 dark:text-gray-600"
+          className="text-ink-muted"
           strokeWidth={0.5}
         />
       ))}
@@ -90,7 +90,7 @@ export default function RadarChart({skills}: {skills: Skill[]}) {
             x2={x}
             y2={y}
             stroke="currentColor"
-            className="text-gray-300 dark:text-gray-600"
+            className="text-ink-muted"
             strokeWidth={0.5}
           />
         );
@@ -130,7 +130,7 @@ export default function RadarChart({skills}: {skills: Skill[]}) {
             y={y}
             textAnchor="middle"
             dominantBaseline="central"
-            className="fill-gray-700 dark:fill-gray-300 text-[10px]"
+            className="fill-ink-soft text-[10px]"
           >
             {skill.name}
           </text>

--- a/app/[locale]/components/ReadingTime.tsx
+++ b/app/[locale]/components/ReadingTime.tsx
@@ -5,7 +5,7 @@ export default function ReadingTime({minutes}: {minutes: number}) {
   const t = useTranslations();
 
   return (
-    <span className="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 text-sm">
+    <span className="inline-flex items-center gap-1 text-ink-muted text-sm">
       <ClockIcon className="h-4 w-4" />
       {t('reading_time', {minutes})}
     </span>

--- a/app/[locale]/components/RelatedPosts.tsx
+++ b/app/[locale]/components/RelatedPosts.tsx
@@ -15,8 +15,8 @@ export default function RelatedPosts({postId, locale}: Props) {
   if (related.length === 0) return null;
 
   return (
-    <section className="mt-12 pt-8 border-t border-gray-200 dark:border-gray-700">
-      <h2 className="text-xl font-bold mb-4 text-gray-900 dark:text-gray-100">
+    <section className="mt-12 pt-8 border-t border-rule">
+      <h2 className="text-xl font-bold mb-4 text-ink">
         {t('related_posts')}
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -24,14 +24,14 @@ export default function RelatedPosts({postId, locale}: Props) {
           <Link
             key={post.id}
             href={`/${locale}/posts/${post.id}`}
-            className="block p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-600 transition-colors no-underline"
+            className="block p-4 rounded-lg border border-rule hover:border-accent transition-colors no-underline"
           >
-            <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1 text-sm">
+            <h3 className="font-semibold text-ink mb-1 text-sm">
               {post.title}
             </h3>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">{post.date}</p>
+            <p className="text-xs text-ink-muted mb-2">{post.date}</p>
             {post.description && (
-              <p className="text-sm text-gray-600 dark:text-gray-300 mb-3 line-clamp-2">
+              <p className="text-sm text-ink-soft mb-3 line-clamp-2">
                 {post.description}
               </p>
             )}

--- a/app/[locale]/components/ScrollToTop.tsx
+++ b/app/[locale]/components/ScrollToTop.tsx
@@ -15,7 +15,7 @@ export default function ScrollToTop() {
   return (
     <button
       onClick={() => window.scrollTo({top: 0, behavior: 'smooth'})}
-      className={`fixed bottom-6 right-6 z-50 p-2 rounded-full bg-blue-600 text-white shadow-lg transition-all duration-300 hover:bg-blue-700 ${
+      className={`fixed bottom-6 right-6 z-50 p-2 rounded-full bg-accent text-accent-fg shadow-lg transition-all duration-300 hover:opacity-90 ${
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4 pointer-events-none'
       }`}
       aria-label="Scroll to top"

--- a/app/[locale]/components/SkillBar.tsx
+++ b/app/[locale]/components/SkillBar.tsx
@@ -41,9 +41,9 @@ export default function SkillBar({skills}: {skills: Skill[]}) {
         <div key={skill.name}>
           <div className="flex justify-between mb-1">
             <span className="text-sm font-medium">{skill.name}</span>
-            <span className="text-xs text-gray-500 dark:text-gray-400">{skill.level}%</span>
+            <span className="text-xs text-ink-muted">{skill.level}%</span>
           </div>
-          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5 overflow-hidden">
+          <div className="w-full bg-bg-alt rounded-full h-2.5 overflow-hidden">
             <div
               className={`h-2.5 rounded-full transition-all duration-1000 ease-out ${skill.color ?? colors[i % colors.length]}`}
               style={{width: animated ? `${skill.level}%` : '0%'}}

--- a/app/[locale]/components/TableOfContents.tsx
+++ b/app/[locale]/components/TableOfContents.tsx
@@ -68,10 +68,10 @@ export default function TableOfContents() {
         style={{left: 'calc(50% + 20rem)'}}
         aria-label={t('toc')}
       >
-        <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
+        <p className="text-sm font-semibold text-ink mb-3">
           {t('toc')}
         </p>
-        <ul className="space-y-1.5 text-sm border-l-2 border-gray-200 dark:border-gray-700">
+        <ul className="space-y-1.5 text-sm border-l-2 border-rule">
           {headings.map((h) => (
             <li key={h.id}>
               <a
@@ -80,8 +80,8 @@ export default function TableOfContents() {
                   h.level === 3 ? 'pl-6' : 'pl-3'
                 } ${
                   activeId === h.id
-                    ? 'text-blue-600 dark:text-blue-400 border-l-2 border-blue-600 dark:border-blue-400 -ml-[2px]'
-                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                    ? 'text-accent border-l-2 border-accent -ml-[2px]'
+                    : 'text-ink-muted hover:text-ink'
                 }`}
               >
                 {h.text}
@@ -95,7 +95,7 @@ export default function TableOfContents() {
       <div className="xl:hidden mb-6">
         <button
           onClick={() => setIsOpen(!isOpen)}
-          className="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+          className="flex items-center gap-2 text-sm font-medium text-ink-soft hover:text-ink transition-colors"
           aria-expanded={isOpen}
         >
           <svg
@@ -110,7 +110,7 @@ export default function TableOfContents() {
         </button>
         {isOpen && (
           <nav className="mt-2 ml-2" aria-label={t('toc')}>
-            <ul className="space-y-1 text-sm border-l-2 border-gray-200 dark:border-gray-700">
+            <ul className="space-y-1 text-sm border-l-2 border-rule">
               {headings.map((h) => (
                 <li key={h.id}>
                   <a
@@ -120,8 +120,8 @@ export default function TableOfContents() {
                       h.level === 3 ? 'pl-6' : 'pl-3'
                     } ${
                       activeId === h.id
-                        ? 'text-blue-600 dark:text-blue-400'
-                        : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                        ? 'text-accent'
+                        : 'text-ink-muted hover:text-ink'
                     }`}
                   >
                     {h.text}

--- a/app/[locale]/components/TagPill.tsx
+++ b/app/[locale]/components/TagPill.tsx
@@ -1,6 +1,6 @@
 export default function TagPill({tag}: {tag: string}) {
   return (
-    <span className="inline-block px-2 py-0.5 text-xs font-medium rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+    <span className="inline-block px-2 py-0.5 text-xs font-medium rounded-full bg-accent-soft text-accent">
       {tag}
     </span>
   );

--- a/app/[locale]/components/Timeline.tsx
+++ b/app/[locale]/components/Timeline.tsx
@@ -47,16 +47,16 @@ export default function Timeline({entries}: {entries: TimelineEntry[]}) {
   return (
     <div className="relative">
       {/* Center line (desktop) / left line (mobile) */}
-      <div className="absolute left-4 md:left-1/2 top-0 bottom-0 w-0.5 bg-gray-300 dark:bg-gray-600 md:-translate-x-px" />
+      <div className="absolute left-4 md:left-1/2 top-0 bottom-0 w-0.5 bg-bg-alt md:-translate-x-px" />
 
       {entries.map((entry, i) => {
         const isLeft = i % 2 === 0;
 
         const card = (
-          <div className="p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600 transition-all">
-            <div className="text-sm text-gray-500 dark:text-gray-400 mb-1">{entry.date}</div>
+          <div className="p-4 rounded-lg border border-rule bg-paper shadow-sm hover:shadow-md hover:border-accent transition-all">
+            <div className="text-sm text-ink-muted mb-1">{entry.date}</div>
             <h3 className="text-lg font-semibold mb-2">{entry.title}</h3>
-            <div className="text-gray-700 dark:text-gray-300 text-sm">{entry.content}</div>
+            <div className="text-ink-soft text-sm">{entry.content}</div>
           </div>
         );
 
@@ -74,7 +74,7 @@ export default function Timeline({entries}: {entries: TimelineEntry[]}) {
             } ${isLeft ? 'md:pr-[calc(50%+1rem)] md:text-right' : 'md:pl-[calc(50%+1rem)]'}`}
           >
             {/* Dot */}
-            <div className="absolute left-4 md:left-1/2 top-6 w-4 h-4 -translate-x-1/2 rounded-full bg-blue-500 border-2 border-white dark:border-gray-900 z-10" />
+            <div className="absolute left-4 md:left-1/2 top-6 w-4 h-4 -translate-x-1/2 rounded-full bg-accent border-2 border-white z-10" />
 
             {wrappedCard}
           </div>

--- a/app/[locale]/components/TripCard.tsx
+++ b/app/[locale]/components/TripCard.tsx
@@ -22,25 +22,25 @@ export default function TripCard({route, year, days, km, komootTourId, waypoints
   return (
     <div
       data-testid="trip-card"
-      className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden"
+      className="border border-rule rounded-lg overflow-hidden"
     >
       <button
         type="button"
         onClick={() => hasMap && setExpanded((prev) => !prev)}
-        className={`w-full text-left p-4 ${hasMap ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800' : ''} transition-colors`}
+        className={`w-full text-left p-4 ${hasMap ? 'cursor-pointer hover:bg-bg-alt' : ''} transition-colors`}
       >
         <div className="flex items-center justify-between">
-          <h3 className="font-semibold text-gray-900 dark:text-gray-100">{route}</h3>
-          <span className="text-xs px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300">
+          <h3 className="font-semibold text-ink">{route}</h3>
+          <span className="text-xs px-2 py-0.5 rounded-full bg-accent-soft text-accent">
             {year}
           </span>
         </div>
-        <div className="flex gap-4 mt-2 text-sm text-gray-500 dark:text-gray-400">
+        <div className="flex gap-4 mt-2 text-sm text-ink-muted">
           <span>{days} {dayLabel}</span>
           <span>{km} km</span>
         </div>
         {hasMap && (
-          <div className="mt-2 text-xs text-blue-600 dark:text-blue-400 flex items-center gap-1">
+          <div className="mt-2 text-xs text-accent flex items-center gap-1">
             <svg
               className={`w-3 h-3 transition-transform duration-300 ${expanded ? 'rotate-180' : ''}`}
               fill="none"
@@ -56,10 +56,10 @@ export default function TripCard({route, year, days, km, komootTourId, waypoints
       </button>
 
       {expanded && hasMap && (
-        <div className="border-t border-gray-200 dark:border-gray-700">
+        <div className="border-t border-rule">
           <Suspense
             fallback={
-              <div className="h-[300px] flex items-center justify-center text-gray-400">
+              <div className="h-[300px] flex items-center justify-center text-ink-muted">
                 Loading map...
               </div>
             }

--- a/app/[locale]/components/TripSummary.tsx
+++ b/app/[locale]/components/TripSummary.tsx
@@ -8,17 +8,17 @@ type Props = {
 export default function TripSummary({totalTrips, totalKm, totalDays, labels}: Props) {
   return (
     <div data-testid="trip-summary" className="grid grid-cols-1 sm:grid-cols-3 gap-4 my-6">
-      <div className="text-center p-4 rounded-lg bg-gray-50 dark:bg-gray-800">
-        <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">{totalTrips}</div>
-        <div className="text-sm text-gray-500 dark:text-gray-400">{labels.trips}</div>
+      <div className="text-center p-4 rounded-lg bg-bg-alt">
+        <div className="text-3xl font-bold text-accent">{totalTrips}</div>
+        <div className="text-sm text-ink-muted">{labels.trips}</div>
       </div>
-      <div className="text-center p-4 rounded-lg bg-gray-50 dark:bg-gray-800">
-        <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">{totalKm.toLocaleString()}</div>
-        <div className="text-sm text-gray-500 dark:text-gray-400">{labels.km}</div>
+      <div className="text-center p-4 rounded-lg bg-bg-alt">
+        <div className="text-3xl font-bold text-accent">{totalKm.toLocaleString()}</div>
+        <div className="text-sm text-ink-muted">{labels.km}</div>
       </div>
-      <div className="text-center p-4 rounded-lg bg-gray-50 dark:bg-gray-800">
-        <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">{totalDays}</div>
-        <div className="text-sm text-gray-500 dark:text-gray-400">{labels.days}</div>
+      <div className="text-center p-4 rounded-lg bg-bg-alt">
+        <div className="text-3xl font-bold text-accent">{totalDays}</div>
+        <div className="text-sm text-ink-muted">{labels.days}</div>
       </div>
     </div>
   );

--- a/app/[locale]/components/TypingText.tsx
+++ b/app/[locale]/components/TypingText.tsx
@@ -26,7 +26,7 @@ export default function TypingText({text, speed = 60}: {text: string; speed?: nu
       <span aria-hidden="true">
         {displayed}
         <span
-          className={`inline-block w-[2px] h-[1.1em] bg-white ml-0.5 align-middle ${
+          className={`inline-block w-[2px] h-[1.1em] bg-ink ml-0.5 align-middle ${
             done ? 'animate-blink' : ''
           }`}
         />

--- a/app/[locale]/components/WorldMap.tsx
+++ b/app/[locale]/components/WorldMap.tsx
@@ -141,13 +141,13 @@ export default function WorldMap({languages}: Props) {
       {hoveredLangs.length > 0 && hoveredCountry && (
         <div
           data-testid="map-tooltip"
-          className="absolute top-2 left-1/2 -translate-x-1/2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 shadow-lg pointer-events-none z-10"
+          className="absolute top-2 left-1/2 -translate-x-1/2 bg-paper border border-rule rounded-lg px-3 py-2 shadow-lg pointer-events-none z-10"
         >
-          <p className="font-semibold text-sm text-gray-800 dark:text-gray-200">
+          <p className="font-semibold text-sm text-ink">
             {COUNTRY_MAP[hoveredCountry]?.label}
           </p>
           {hoveredLangs.map((lang) => (
-            <p key={lang.name} className="text-xs text-gray-500 dark:text-gray-400">
+            <p key={lang.name} className="text-xs text-ink-muted">
               {lang.name} — {lang.level}
             </p>
           ))}
@@ -162,7 +162,7 @@ export default function WorldMap({languages}: Props) {
               className="w-3 h-3 rounded-full inline-block"
               style={{backgroundColor: lang.color}}
             />
-            <span className="text-gray-700 dark:text-gray-300">
+            <span className="text-ink-soft">
               {lang.name} — {lang.level}
             </span>
           </div>

--- a/app/[locale]/education/42-Paris/page.tsx
+++ b/app/[locale]/education/42-Paris/page.tsx
@@ -8,7 +8,7 @@ const content = {
     body: (
       <>
         <p>For 3 years, I studied software engineering, software development, software architecture, all in one word: coding.</p>
-        <p className="mt-4"><a href="https://42.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">42</a> is a future-proof computer science training to educate the next generation of software engineers. The 42 program takes a project-based approach to progress and is designed to develop technical and people skills that match the expectations of the labor market.</p>
+        <p className="mt-4"><a href="https://42.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">42</a> is a future-proof computer science training to educate the next generation of software engineers. The 42 program takes a project-based approach to progress and is designed to develop technical and people skills that match the expectations of the labor market.</p>
         <p className="mt-4"><strong>NO COURSES. NO TEACHERS. NO CLASSES.</strong></p>
         <p>Thanks to its innovative teaching methods, 42 is able to offer training par excellence without resorting to lectures. The pedagogical staff is available to help the students find their own solutions. In order to progress at 42, you have to work in groups, lean with the community to overcome challenges and then, share your experience with your peers. You don&apos;t learn programming by copying algorithms on paper!</p>
         <p className="mt-4"><strong>PROJECT-BASED PEDAGOGY</strong></p>
@@ -30,7 +30,7 @@ const content = {
     body: (
       <>
         <p>Pendant 3 ans, j&apos;ai étudié le génie logiciel, le développement logiciel, l&apos;architecture logicielle, le tout en un mot : coder.</p>
-        <p className="mt-4"><a href="https://42.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">42</a> est une formation en informatique tournée vers l&apos;avenir, destinée à former la prochaine génération d&apos;ingénieurs en logiciel. Le programme 42 adopte une approche de progression par projet et est conçu pour développer des compétences techniques et humaines qui correspondent aux attentes du marché du travail.</p>
+        <p className="mt-4"><a href="https://42.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">42</a> est une formation en informatique tournée vers l&apos;avenir, destinée à former la prochaine génération d&apos;ingénieurs en logiciel. Le programme 42 adopte une approche de progression par projet et est conçu pour développer des compétences techniques et humaines qui correspondent aux attentes du marché du travail.</p>
         <p className="mt-4"><strong>PAS DE COURS. PAS DE PROFESSEURS. PAS DE CLASSE.</strong></p>
         <p>Grâce à ses méthodes pédagogiques innovantes, 42 est en mesure d&apos;offrir une formation d&apos;excellence sans recourir aux cours magistraux. L&apos;équipe pédagogique est disponible pour aider les étudiants à trouver leurs propres solutions. Pour progresser à 42, il faut travailler en groupe, s&apos;appuyer sur la communauté pour surmonter les difficultés et ensuite, partager son expérience avec ses pairs. On n&apos;apprend pas la programmation en copiant des algorithmes sur papier !</p>
         <p className="mt-4"><strong>PÉDAGOGIE PAR PROJET</strong></p>
@@ -52,7 +52,7 @@ const content = {
     body: (
       <>
         <p>3 Jahre lang habe ich Software-Engineering, Software-Entwicklung und Software-Architektur studiert, alles in einem Wort: Codierung.</p>
-        <p className="mt-4"><a href="https://42.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">42</a> ist eine zukunftssichere Informatikausbildung, die die nächste Generation von Softwareingenieuren ausbildet. Das 42-Programm verfolgt einen projektbasierten Ansatz, um Fortschritte zu erzielen, und ist darauf ausgerichtet, technische und menschliche Fähigkeiten zu entwickeln, die den Erwartungen des Arbeitsmarktes entsprechen.</p>
+        <p className="mt-4"><a href="https://42.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">42</a> ist eine zukunftssichere Informatikausbildung, die die nächste Generation von Softwareingenieuren ausbildet. Das 42-Programm verfolgt einen projektbasierten Ansatz, um Fortschritte zu erzielen, und ist darauf ausgerichtet, technische und menschliche Fähigkeiten zu entwickeln, die den Erwartungen des Arbeitsmarktes entsprechen.</p>
         <p className="mt-4"><strong>KEINE KURSE. KEINE LEHRER. KEINE KLASSEN.</strong></p>
         <p>Dank seiner innovativen Lehrmethoden ist 42 in der Lage, eine Ausbildung par excellence anzubieten, ohne auf Vorlesungen zurückgreifen zu müssen. Das pädagogische Personal steht zur Verfügung, um den Studenten zu helfen, ihre eigenen Lösungen zu finden. Um bei 42 voranzukommen, muss man in Gruppen arbeiten, sich mit der Gemeinschaft abstimmen, um Herausforderungen zu meistern, und dann seine Erfahrungen mit Gleichaltrigen teilen. Programmieren lernt man nicht durch das Kopieren von Algorithmen auf Papier!</p>
         <p className="mt-4"><strong>PROJEKTBASIERTE PÄDAGOGIK</strong></p>
@@ -74,7 +74,7 @@ const content = {
     body: (
       <>
         <p>Durante 3 años, estudié ingeniería de software, desarrollo de software, arquitectura de software, todo en una palabra: codificación.</p>
-        <p className="mt-4"><a href="https://42.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">42</a> es una formación en ciencias de la computación preparada para el futuro con el fin de educar a la próxima generación de ingenieros de software. El programa 42 adopta un enfoque de progreso basado en proyectos y está diseñado para desarrollar habilidades técnicas y humanas que coincidan con las expectativas del mercado laboral.</p>
+        <p className="mt-4"><a href="https://42.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">42</a> es una formación en ciencias de la computación preparada para el futuro con el fin de educar a la próxima generación de ingenieros de software. El programa 42 adopta un enfoque de progreso basado en proyectos y está diseñado para desarrollar habilidades técnicas y humanas que coincidan con las expectativas del mercado laboral.</p>
         <p className="mt-4"><strong>NO HAY CURSOS. SIN PROFESORES. SIN CLASES.</strong></p>
         <p>Gracias a sus innovadores métodos de enseñanza, 42 es capaz de ofrecer la formación por excelencia sin recurrir a las clases magistrales. El personal pedagógico está disponible para ayudar a los alumnos a encontrar sus propias soluciones. Para progresar en 42, hay que trabajar en grupo, apoyarse en la comunidad para superar los retos y luego, compartir la experiencia con los compañeros. No se aprende a programar copiando algoritmos en papel.</p>
         <p className="mt-4"><strong>PEDAGOGÍA BASADA EN PROYECTOS</strong></p>

--- a/app/[locale]/education/CPGE_BL/page.tsx
+++ b/app/[locale]/education/CPGE_BL/page.tsx
@@ -8,7 +8,7 @@ const content = {
     body: (
       <>
         <p>Preparatory class for the French Grandes Écoles in Literature and Social Sciences.</p>
-        <p>At <a href="https://www.ndplille.fr/cpge" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Notre Dame de la Paix</a>, Lille.</p>
+        <p>At <a href="https://www.ndplille.fr/cpge" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Notre Dame de la Paix</a>, Lille.</p>
         <p>(Hypokhâgne/Khâgne)</p>
         <p className="mt-4">Advanced courses:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
@@ -29,7 +29,7 @@ const content = {
     body: (
       <>
         <p>Classe préparatoire aux Grandes Écoles françaises de lettres et de sciences sociales.</p>
-        <p>À <a href="https://www.ndplille.fr/cpge" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Notre Dame de la Paix</a>, Lille.</p>
+        <p>À <a href="https://www.ndplille.fr/cpge" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Notre Dame de la Paix</a>, Lille.</p>
         <p>(Hypokhâgne/Khâgne)</p>
         <p className="mt-4">Cours avancés :</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
@@ -50,7 +50,7 @@ const content = {
     body: (
       <>
         <p>Vorbereitungsklasse für die französischen Grandes Écoles in Literatur und Sozialwissenschaften.</p>
-        <p>In <a href="https://www.ndplille.fr/cpge" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Notre Dame de la Paix</a>, Lille.</p>
+        <p>In <a href="https://www.ndplille.fr/cpge" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Notre Dame de la Paix</a>, Lille.</p>
         <p>(Hypokhâgne/Khâgne)</p>
         <p className="mt-4">Fortgeschrittene Kurse:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
@@ -71,7 +71,7 @@ const content = {
     body: (
       <>
         <p>Clase preparatoria para las Grandes Écoles francesas de Literatura y Ciencias Sociales.</p>
-        <p>En <a href="https://www.ndplille.fr/cpge" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Notre Dame de la Paix</a>, Lille.</p>
+        <p>En <a href="https://www.ndplille.fr/cpge" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Notre Dame de la Paix</a>, Lille.</p>
         <p>(Hypokhâgne/Khâgne)</p>
         <p className="mt-4">Cursos de perfeccionamiento:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">

--- a/app/[locale]/education/IAE-Lille/page.tsx
+++ b/app/[locale]/education/IAE-Lille/page.tsx
@@ -7,8 +7,8 @@ const content = {
     summary: <p>Masters in International Marketing &amp; Communication at IAE Lille, University School of Management — digital strategy, branding, and intercultural management.</p>,
     body: (
       <>
-        <p><a href="https://iaelille.fr/eformations/master-2-marketing-communication-culture/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Masters in International Marketing &amp; Communication</a></p>
-        <p><a href="https://iaelille.fr/en/home/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">IAE Lille</a>, University School of Management</p>
+        <p><a href="https://iaelille.fr/eformations/master-2-marketing-communication-culture/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Masters in International Marketing &amp; Communication</a></p>
+        <p><a href="https://iaelille.fr/en/home/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">IAE Lille</a>, University School of Management</p>
         <p className="mt-4"><strong>Courses:</strong></p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Digital strategy &amp; Tools</li>
@@ -40,8 +40,8 @@ const content = {
     summary: <p>Master en Marketing International &amp; Communication à l&apos;IAE Lille, École Universitaire de Management — stratégie digitale, image de marque et management interculturel.</p>,
     body: (
       <>
-        <p><a href="https://iaelille.fr/eformations/master-2-marketing-communication-culture/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Master en marketing et communication internationale</a></p>
-        <p><a href="https://iaelille.fr/en/home/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">IAE de Lille</a>, École Universitaire de Management</p>
+        <p><a href="https://iaelille.fr/eformations/master-2-marketing-communication-culture/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Master en marketing et communication internationale</a></p>
+        <p><a href="https://iaelille.fr/en/home/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">IAE de Lille</a>, École Universitaire de Management</p>
         <p className="mt-4"><strong>Cours :</strong></p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Stratégie et outils numériques</li>
@@ -73,8 +73,8 @@ const content = {
     summary: <p>Master in Internationalem Marketing &amp; Kommunikation an der IAE Lille, Hochschule für Management — digitale Strategie, Branding und interkulturelles Management.</p>,
     body: (
       <>
-        <p><a href="https://iaelille.fr/eformations/master-2-marketing-communication-culture/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Master in Internationalem Marketing und Kommunikation</a></p>
-        <p><a href="https://iaelille.fr/en/home/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">IAE Lille</a>, Hochschule für Management</p>
+        <p><a href="https://iaelille.fr/eformations/master-2-marketing-communication-culture/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Master in Internationalem Marketing und Kommunikation</a></p>
+        <p><a href="https://iaelille.fr/en/home/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">IAE Lille</a>, Hochschule für Management</p>
         <p className="mt-4"><strong>Kurse:</strong></p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Digitale Strategie &amp; Tools</li>
@@ -106,8 +106,8 @@ const content = {
     summary: <p>Máster en Marketing Internacional y Comunicación en IAE Lille, Escuela Universitaria de Gestión — estrategia digital, marca y gestión intercultural.</p>,
     body: (
       <>
-        <p><a href="https://iaelille.fr/eformations/master-2-marketing-communication-culture/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Máster en Marketing y Comunicación Internacional</a></p>
-        <p><a href="https://iaelille.fr/en/home/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">IAE Lille</a>, Escuela Universitaria de Gestión</p>
+        <p><a href="https://iaelille.fr/eformations/master-2-marketing-communication-culture/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Máster en Marketing y Comunicación Internacional</a></p>
+        <p><a href="https://iaelille.fr/en/home/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">IAE Lille</a>, Escuela Universitaria de Gestión</p>
         <p className="mt-4"><strong>Cursos:</strong></p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Estrategia y herramientas digitales</li>

--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -8,10 +8,10 @@ export default function Error({error, reset}: {error: Error & {digest?: string};
   return (
     <div className="flex flex-col items-center justify-center min-h-[50vh] text-center">
       <h2 className="text-2xl font-bold mb-4">{t('error_title')}</h2>
-      <p className="text-gray-600 dark:text-gray-400 mb-6">{t('error_message')}</p>
+      <p className="text-ink-soft mb-6">{t('error_message')}</p>
       <button
         onClick={reset}
-        className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+        className="px-4 py-2 bg-accent text-accent-fg rounded-md hover:opacity-90 transition-colors"
       >
         {t('error_retry')}
       </button>

--- a/app/[locale]/experience/ESF-Sciences-Humaines/page.tsx
+++ b/app/[locale]/experience/ESF-Sciences-Humaines/page.tsx
@@ -7,7 +7,7 @@ const content = {
     summary: <p>Product Manager at ESF Sciences Humaines (2018-2019) — business strategy, analysis, and digital marketing.</p>,
     body: (
       <>
-        <p>Product Manager - <a href="https://www.esf-scienceshumaines.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">ESF Sciences Humaines</a> (2018 - 2019)</p>
+        <p>Product Manager - <a href="https://www.esf-scienceshumaines.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">ESF Sciences Humaines</a> (2018 - 2019)</p>
         <p className="mt-4">Missions:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Business Strategy (diversify acquisition sources)</li>
@@ -22,7 +22,7 @@ const content = {
     summary: <p>Chef de produit chez ESF Sciences Humaines (2018-2019) — stratégie commerciale, analyse et marketing digital.</p>,
     body: (
       <>
-        <p>Chef de produit - <a href="https://www.esf-scienceshumaines.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">ESF Sciences Humaines</a> (2018 - 2019)</p>
+        <p>Chef de produit - <a href="https://www.esf-scienceshumaines.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">ESF Sciences Humaines</a> (2018 - 2019)</p>
         <p className="mt-4">Missions :</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Stratégie commerciale (diversifier les sources d&apos;acquisition)</li>
@@ -37,7 +37,7 @@ const content = {
     summary: <p>Produktmanager bei ESF Sciences Humaines (2018-2019) — Geschäftsstrategie, Analyse und digitales Marketing.</p>,
     body: (
       <>
-        <p>Produktmanager - <a href="https://www.esf-scienceshumaines.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">ESF Sciences Humaines</a> (2018 - 2019)</p>
+        <p>Produktmanager - <a href="https://www.esf-scienceshumaines.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">ESF Sciences Humaines</a> (2018 - 2019)</p>
         <p className="mt-4">Aufgaben:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Geschäftsstrategie (Diversifizierung der Erwerbsquellen)</li>
@@ -52,7 +52,7 @@ const content = {
     summary: <p>Gerente de producto en ESF Sciences Humaines (2018-2019) — estrategia comercial, análisis y marketing digital.</p>,
     body: (
       <>
-        <p>Responsable de producto - <a href="https://www.esf-scienceshumaines.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">ESF Sciences Humaines</a> (2018 - 2019)</p>
+        <p>Responsable de producto - <a href="https://www.esf-scienceshumaines.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">ESF Sciences Humaines</a> (2018 - 2019)</p>
         <p className="mt-4">Misiones:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Estrategia comercial (diversificar las fuentes de adquisición)</li>

--- a/app/[locale]/experience/Editions-Denoel/page.tsx
+++ b/app/[locale]/experience/Editions-Denoel/page.tsx
@@ -7,7 +7,7 @@ const content = {
     summary: <p>Marketing Assistant at Editions Denoël (2015-2017) — brand identity, sales promotion, and business analysis.</p>,
     body: (
       <>
-        <p>Marketing Assistant - <a href="http://www.denoel.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Editions Denoël</a> (2015 - 2017) - apprenticeship</p>
+        <p>Marketing Assistant - <a href="http://www.denoel.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Editions Denoël</a> (2015 - 2017) - apprenticeship</p>
         <p className="mt-4">Missions:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Brand Identity (makeover supervision)</li>
@@ -22,7 +22,7 @@ const content = {
     summary: <p>Assistant Marketing chez Editions Denoël (2015-2017) — identité de marque, promotion des ventes et analyse commerciale.</p>,
     body: (
       <>
-        <p>Assistant Marketing - <a href="http://www.denoel.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Editions Denoël</a> (2015 - 2017) - apprentissage</p>
+        <p>Assistant Marketing - <a href="http://www.denoel.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Editions Denoël</a> (2015 - 2017) - apprentissage</p>
         <p className="mt-4">Missions :</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Identité de marque (supervision de la refondation)</li>
@@ -37,7 +37,7 @@ const content = {
     summary: <p>Marketingassistent bei Editions Denoël (2015-2017) — Markenidentität, Verkaufsförderung und Geschäftsanalyse.</p>,
     body: (
       <>
-        <p>Marketingassistent - <a href="http://www.denoel.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Editions Denoël</a> (2015 - 2017) - Ausbildung</p>
+        <p>Marketingassistent - <a href="http://www.denoel.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Editions Denoël</a> (2015 - 2017) - Ausbildung</p>
         <p className="mt-4">Aufgaben:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Markenidentität (Überwachung der Umgestaltung)</li>
@@ -52,7 +52,7 @@ const content = {
     summary: <p>Asistente de marketing en Editions Denoël (2015-2017) — identidad de marca, promoción de ventas y análisis comercial.</p>,
     body: (
       <>
-        <p>Asistente de marketing - <a href="http://www.denoel.fr/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Editions Denoël</a> (2015 - 2017) - aprendizaje</p>
+        <p>Asistente de marketing - <a href="http://www.denoel.fr/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Editions Denoël</a> (2015 - 2017) - aprendizaje</p>
         <p className="mt-4">Misiones:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Identidad de marca (supervisión del cambio de imagen)</li>

--- a/app/[locale]/experience/Flammarion/page.tsx
+++ b/app/[locale]/experience/Flammarion/page.tsx
@@ -7,7 +7,7 @@ const content = {
     summary: <p>Press Relationships Assistant at Flammarion (2015) — database management and media research.</p>,
     body: (
       <>
-        <p>Press Relationships Assistant - <a href="https://editions.flammarion.com/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Flammarion</a> (2015) - internship</p>
+        <p>Press Relationships Assistant - <a href="https://editions.flammarion.com/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Flammarion</a> (2015) - internship</p>
         <p className="mt-4">Missions:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Database management: Eudonet and Data Press.</li>
@@ -26,7 +26,7 @@ const content = {
     summary: <p>Assistant relations presse chez Flammarion (2015) — gestion de bases de données et veille médias.</p>,
     body: (
       <>
-        <p>Assistant relations presse - <a href="https://editions.flammarion.com/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Flammarion</a> (2015) - stage</p>
+        <p>Assistant relations presse - <a href="https://editions.flammarion.com/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Flammarion</a> (2015) - stage</p>
         <p className="mt-4">Missions :</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Gestion des bases de données : Eudonet et Data Press.</li>
@@ -45,7 +45,7 @@ const content = {
     summary: <p>Assistentin für Pressearbeit bei Flammarion (2015) — Datenbankverwaltung und Medienforschung.</p>,
     body: (
       <>
-        <p>Assistentin für Pressearbeit - <a href="https://editions.flammarion.com/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Flammarion</a> (2015) - Praktikum</p>
+        <p>Assistentin für Pressearbeit - <a href="https://editions.flammarion.com/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Flammarion</a> (2015) - Praktikum</p>
         <p className="mt-4">Aufgaben:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Datenbankverwaltung: Eudonet und Data Press.</li>
@@ -64,7 +64,7 @@ const content = {
     summary: <p>Asistente de relaciones con la prensa en Flammarion (2015) — gestión de bases de datos e investigación de medios.</p>,
     body: (
       <>
-        <p>Asistente de relaciones con la prensa - <a href="https://editions.flammarion.com/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Flammarion</a> (2015) - prácticas</p>
+        <p>Asistente de relaciones con la prensa - <a href="https://editions.flammarion.com/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Flammarion</a> (2015) - prácticas</p>
         <p className="mt-4">Misiones:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Gestión de bases de datos: Eudonet y Data Press.</li>

--- a/app/[locale]/experience/Junior-42-Paris/page.tsx
+++ b/app/[locale]/experience/Junior-42-Paris/page.tsx
@@ -7,7 +7,7 @@ const content = {
     summary: <p>Junior company created in 2019 — Business Manager managing a team of 12 Project Leaders and 4 Technical Experts during the Client Qualification phase.</p>,
     body: (
       <>
-        <p><a href="https://junior42.com/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Junior 42 Paris</a> is a junior company created in 2019. A junior company is both a company and a non-profit. This special status enables students to perform missions for clients, and get another sense of the professional world.</p>
+        <p><a href="https://junior42.com/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Junior 42 Paris</a> is a junior company created in 2019. A junior company is both a company and a non-profit. This special status enables students to perform missions for clients, and get another sense of the professional world.</p>
         <p className="mt-4"><strong>Business Manager:</strong> my role was to form, help, and manage a team of 12 Project Leaders and 4 Technical Experts, during the first phase of interactions with the clients, a phase we called <strong>Client Qualification</strong>.</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>My work on this post has been to standardize and optimize all the processes around it, so we could achieve both vertical and horizontal scaling. I&apos;m glad to say it was a success since we went from 44 prospects to 87 in one year and maintained our conversion rate.</li>
@@ -21,7 +21,7 @@ const content = {
     summary: <p>Junior entreprise créée en 2019 — Business Manager gérant une équipe de 12 chefs de projets et 4 experts techniques lors de la phase de qualification client.</p>,
     body: (
       <>
-        <p><a href="https://junior42.com/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Junior 42 Paris</a> est une junior entreprise créée en 2019. Une junior entreprise est à la fois une entreprise et une association à but non lucratif. Ce statut particulier permet aux étudiants de réaliser des missions pour des clients, et de se faire une autre idée du monde professionnel.</p>
+        <p><a href="https://junior42.com/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Junior 42 Paris</a> est une junior entreprise créée en 2019. Une junior entreprise est à la fois une entreprise et une association à but non lucratif. Ce statut particulier permet aux étudiants de réaliser des missions pour des clients, et de se faire une autre idée du monde professionnel.</p>
         <p className="mt-4"><strong>Business Manager :</strong> mon rôle était de former, d&apos;aider et de gérer une équipe de 12 chefs de projets et 4 experts techniques, lors de la première phase d&apos;interactions avec les clients, phase que nous avons appelée <strong>Client Qualification</strong>.</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Mon travail sur ce poste a consisté à normaliser et à optimiser tous les processus qui l&apos;entourent, afin que nous puissions réaliser une mise à l&apos;échelle verticale et horizontale. Je suis heureux de dire que cela a été un succès puisque nous sommes passés de 44 prospects à 87 en un an et que nous avons maintenu notre taux de conversion.</li>
@@ -35,7 +35,7 @@ const content = {
     summary: <p>2019 gegründete Juniorfirma — Business Manager eines Teams von 12 Projektleitern und 4 technischen Experten in der Phase der Kundenqualifizierung.</p>,
     body: (
       <>
-        <p><a href="https://junior42.com/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Junior 42 Paris</a> ist eine im Jahr 2019 gegründete Juniorfirma. Eine Juniorfirma ist sowohl ein Unternehmen als auch eine gemeinnützige Einrichtung. Dieser besondere Status ermöglicht es Studenten, Aufträge für Kunden auszuführen und einen anderen Einblick in die Berufswelt zu bekommen.</p>
+        <p><a href="https://junior42.com/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Junior 42 Paris</a> ist eine im Jahr 2019 gegründete Juniorfirma. Eine Juniorfirma ist sowohl ein Unternehmen als auch eine gemeinnützige Einrichtung. Dieser besondere Status ermöglicht es Studenten, Aufträge für Kunden auszuführen und einen anderen Einblick in die Berufswelt zu bekommen.</p>
         <p className="mt-4"><strong>Business Manager:</strong> Meine Aufgabe war es, ein Team von 12 Projektleitern und 4 technischen Experten zu bilden, zu unterstützen und zu leiten, und zwar in der ersten Phase der Interaktion mit den Kunden, die wir <strong>Client Qualification</strong> nennen.</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Meine Arbeit in diesem Bereich bestand darin, alle Prozesse zu standardisieren und zu optimieren, damit wir sowohl eine vertikale als auch eine horizontale Skalierung erreichen konnten. Ich freue mich, sagen zu können, dass es ein Erfolg war, da wir innerhalb eines Jahres von 44 auf 87 potenzielle Kunden gestiegen sind und unsere Konversionsrate beibehalten haben.</li>
@@ -49,7 +49,7 @@ const content = {
     summary: <p>Empresa junior creada en 2019 — Gerente de negocio gestionando un equipo de 12 líderes de proyecto y 4 expertos técnicos durante la fase de calificación del cliente.</p>,
     body: (
       <>
-        <p><a href="https://junior42.com/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Junior 42 Paris</a> es una empresa junior creada en 2019. Una empresa junior es a la vez una empresa y una organización sin ánimo de lucro. Este estatus especial permite a los estudiantes realizar misiones para los clientes, y obtener otro sentido del mundo profesional.</p>
+        <p><a href="https://junior42.com/" className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">Junior 42 Paris</a> es una empresa junior creada en 2019. Una empresa junior es a la vez una empresa y una organización sin ánimo de lucro. Este estatus especial permite a los estudiantes realizar misiones para los clientes, y obtener otro sentido del mundo profesional.</p>
         <p className="mt-4"><strong>Gerente de negocio:</strong> mi papel era formar, ayudar y gestionar un equipo de 12 líderes de proyecto y 4 expertos técnicos, durante la primera fase de las interacciones con los clientes, una fase que llamamos <strong>Calificación del cliente</strong>.</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Mi trabajo en este puesto ha consistido en estandarizar y optimizar todos los procesos en torno a él, de modo que pudiéramos conseguir un escalado tanto vertical como horizontal. Me alegra decir que fue un éxito ya que pasamos de 44 prospectos a 87 en un año y mantuvimos nuestra tasa de conversión.</li>

--- a/app/[locale]/hobbies/graphic-novels/page.tsx
+++ b/app/[locale]/hobbies/graphic-novels/page.tsx
@@ -3,7 +3,7 @@ const content = {
   en: {
     title: 'Graphic Novels',
     intro: (
-      <p className="text-gray-600 italic mb-6">
+      <p className="text-ink-soft italic mb-6">
         I like them (a lot). I buy them (when I can).
       </p>
     ),
@@ -12,7 +12,7 @@ const content = {
   fr: {
     title: 'Romans graphiques',
     intro: (
-      <p className="text-gray-600 italic mb-6">
+      <p className="text-ink-soft italic mb-6">
         Je les aime (beaucoup). J’en achète (quand je peux).
       </p>
     ),
@@ -21,7 +21,7 @@ const content = {
   de: {
     title: 'Graphic Novels',
     intro: (
-      <p className="text-gray-600 italic mb-6">
+      <p className="text-ink-soft italic mb-6">
         Ich mag sie (sehr). Ich kaufe sie (wenn ich kann).
       </p>
     ),
@@ -30,7 +30,7 @@ const content = {
   es: {
     title: 'Novelas gráficas',
     intro: (
-      <p className="text-gray-600 italic mb-6">
+      <p className="text-ink-soft italic mb-6">
         Me gustan (mucho). Los compro (cuando puedo).
       </p>
     ),
@@ -295,7 +295,7 @@ export default async function GraphicNovelsPage({params}: {params: Promise<{loca
             <div
               key={novel.title}
               data-testid="graphic-novel-card"
-              className="border border-gray-200 rounded-lg overflow-hidden flex flex-col"
+              className="border border-rule rounded-lg overflow-hidden flex flex-col"
             >
               <div
                 className="h-120 flex items-end p-1"
@@ -318,12 +318,12 @@ export default async function GraphicNovelsPage({params}: {params: Promise<{loca
               </div>
               <div className="p-4 flex flex-col gap-2 flex-1">
                 <div className="flex items-start justify-between gap-2">
-                  <span className="text-sm text-gray-500">{novel.author}</span>
+                  <span className="text-sm text-ink-muted">{novel.author}</span>
                   <span className="text-xs px-2 py-0.5 rounded-full bg-purple-100 text-purple-700 whitespace-nowrap">
                     {novel.genre[locale as Locale] ?? novel.genre.en}
                   </span>
                 </div>
-                <p className="text-sm text-gray-700 italic leading-snug">{novel.take}</p>
+                <p className="text-sm text-ink-soft italic leading-snug">{novel.take}</p>
               </div>
             </div>
           ))}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -79,7 +79,7 @@ export default async function LocaleLayout({children, params}: Props) {
       <body>
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-accent focus:text-accent-fg focus:rounded"
         >
           Skip to content
         </a>

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -7,8 +7,8 @@ export default async function NotFound() {
   return (
     <div className="flex flex-col items-center justify-center min-h-[50vh] text-center">
       <h2 className="text-2xl font-bold mb-4">{t('not_found_title')}</h2>
-      <p className="text-gray-600 mb-6">{t('not_found_message')}</p>
-      <Link href="/" className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors">
+      <p className="text-ink-soft mb-6">{t('not_found_message')}</p>
+      <Link href="/" className="px-4 py-2 bg-accent text-accent-fg rounded-md hover:opacity-90 transition-colors">
         {t('back_home')}
       </Link>
     </div>

--- a/app/[locale]/skills/soft-skills/page.tsx
+++ b/app/[locale]/skills/soft-skills/page.tsx
@@ -4,7 +4,7 @@ const skills = [
   {
     id: 'stakeholder',
     icon: (
-      <svg className="w-10 h-10 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg className="w-10 h-10 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
       </svg>
     ),
@@ -122,7 +122,7 @@ export default async function SoftSkillsPage({params}: {params: Promise<{locale:
                 </div>
               }
               back={
-                <p className="text-sm text-center text-gray-600 dark:text-gray-300">
+                <p className="text-sm text-center text-ink-soft">
                   {skillDescriptions[skill.id]?.[locale] ?? skillDescriptions[skill.id]?.en}
                 </p>
               }

--- a/app/[locale]/skills/stack/page.tsx
+++ b/app/[locale]/skills/stack/page.tsx
@@ -34,7 +34,7 @@ export default async function StackPage({params}: {params: Promise<{locale: stri
   return (
     <>      <article>
         <h1 className="text-3xl font-extrabold tracking-tight my-4">{t.title}</h1>
-        <div className="text-gray-500 mb-4">2022-05-12</div>
+        <div className="text-ink-muted mb-4">2022-05-12</div>
         <RadarChart skills={skills} />
         <h2 className="text-xl font-bold mt-8 mb-4">Proficiency</h2>
         <SkillBar skills={skills} />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,8 @@
    ============================================================= */
 
 :root {
+  color-scheme: light dark;
+
   --font-display: var(--font-instrument-serif), "Times New Roman", Georgia, serif;
   --font-body: var(--font-inter-tight), -apple-system, "Helvetica Neue", Arial, sans-serif;
   --font-mono: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -30,6 +32,58 @@
   --dur-1: 180ms;
   --dur-2: 360ms;
   --dur-3: 600ms;
+
+  /* A soft accent wash for chips/badges (the old bg-blue-100). Derived
+     from --accent + --bg, so it re-tints itself in dark mode for free. */
+  --accent-soft: color-mix(in oklab, var(--accent) 14%, var(--bg));
+}
+
+/* Expose the palette tokens as Tailwind colour utilities (text-ink,
+   bg-paper, border-rule, bg-accent-soft, …). `inline` makes each utility
+   resolve the token's *current* value rather than freezing it, so the
+   dark-mode overrides below flow through the utilities automatically. */
+@theme inline {
+  --color-ink:         var(--ink);
+  --color-ink-soft:    var(--ink-soft);
+  --color-ink-muted:   var(--ink-muted);
+  --color-paper:       var(--paper);
+  --color-bg-alt:      var(--bg-alt);
+  --color-rule:        var(--rule);
+  --color-accent:      var(--accent);
+  --color-accent-fg:   var(--accent-fg);
+  --color-accent-soft: var(--accent-soft);
+}
+
+/* -------------------------------------------------------------
+   Dark counterpart — the ink becomes the page.
+
+   Only the ten colour tokens are redefined. Everything downstream
+   follows on its own: 67 uses of --rule, 83 of --accent, and the 13
+   color-mix(in oklab, var(--ink) …) derivations all re-resolve here.
+
+   Deliberately NOT overridden: the physical objects in the scrapbook
+   (photo print #fdfaf3, sticky note #fff8c5, book spines) and the
+   status dot. A photo print stays the colour of paper whatever the
+   light in the room. The cursor-follower is likewise untouched — it
+   uses mix-blend-mode: difference, so it inverts itself.
+   ------------------------------------------------------------- */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #141311;  /* the light palette's --ink, exactly */
+    --bg-alt:    #1e1b17;
+    --ink:       #ece7dc;  /* the light palette's --bg-alt: softer than
+                              full cream, which haloes on a dark field */
+    --ink-soft:  #b3aa9b;
+    --ink-muted: #8b8375;  /* 4.95:1 — actually clears AA, where the
+                              light counterpart only reaches 3.62:1 */
+    --rule:      #ece7dc1f;
+    --accent:    #7d9bff;  /* #1e48ff manages just 3.03:1 on this
+                              background; lightened to 7.08:1 */
+    --accent-fg: #141311;
+    --paper:     #1c1917;
+    --stamp:     #7d9bff;
+  }
 }
 
 @layer base {
@@ -61,6 +115,43 @@
   ::-webkit-scrollbar { width: 10px; height: 10px; }
   ::-webkit-scrollbar-thumb { background: color-mix(in oklab, var(--ink) 20%, transparent); border-radius: 999px; }
   ::-webkit-scrollbar-track { background: transparent; }
+}
+
+/* =============================================================
+   CODE BLOCKS — shiki dual-theme wiring
+
+   CodeBlock.tsx calls codeToHtml with defaultColor:false, so shiki
+   emits no `color` of its own — only --shiki-light / --shiki-dark
+   custom properties per token. Without the rules below every token
+   simply inherits --ink and the block renders as flat, unhighlighted
+   text. Nothing consumed these variables before.
+
+   We take shiki's *syntax* colours but not its backgrounds: the block
+   sits on --paper so it stays in the Paper & Ink family rather than
+   dropping github-dark's cool #24292e slab onto warm paper. That also
+   reads better — github-dark's palette scores higher on our #1c1917
+   than on its own native background (keyword 6.58:1 vs 5.52:1).
+   ============================================================= */
+
+.shiki,
+.shiki span { color: var(--shiki-light); }
+
+@media (prefers-color-scheme: dark) {
+  .shiki,
+  .shiki span { color: var(--shiki-dark); }
+}
+
+/* .article code / .detail-article code style *inline* code with a
+   --bg-alt chip and padding. Shiki's output is <pre class="shiki"><code>,
+   which matches those selectors too, so the chip has to be undone
+   inside a highlighted block. */
+.article .shiki code,
+.detail-article .shiki code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+  color: inherit;
 }
 
 /* =============================================================


### PR DESCRIPTION
Stacked on #18 (the dependency upgrade) — its base is `claude/website-lib-upgrades-562119`, so review/merge #18 first; GitHub will retarget this to `main` automatically.

Fixes two linked gaps found during the upgrade and documented in `.debug/006`.

## Problem

1. **Code blocks rendered with no syntax highlighting.** `CodeBlock.tsx` calls shiki with `defaultColor: false`, so shiki emits only `--shiki-light` / `--shiki-dark` CSS variables per token and no `color`. Nothing in `globals.css` consumed them, so every token inherited the body ink — flat, unhighlighted text.
2. **Dark mode was half-built.** `globals.css` had no `prefers-color-scheme` block, yet ~34 components/pages carried `dark:` Tailwind variants. A visitor on a dark OS got a broken half-dark page; in light mode those same files rendered cool `gray-*`/`blue-*` chrome that clashed with the warm "Paper & Ink" palette.

## Change

**Commit 1 — CSS foundation:**
- A `@media (prefers-color-scheme: dark)` block redefining the ten palette tokens (`--bg`, `--ink`, `--accent`, …). Everything downstream (67 `--rule` uses, 83 `--accent`, the `color-mix` derivations) re-resolves for free. All dark values are WCAG-checked (the `#1e48ff` accent only reaches 3.03:1 on dark, so it's lightened to `#7d9bff` = 7.08:1).
- A `.shiki` mapping consuming `--shiki-light` / `--shiki-dark`, swapped under the dark query. The block keeps shiki's *syntax* colours but drops its background so code sits on `--paper` — which also scores better (github-dark keyword 6.58:1 on our surface vs 5.52:1 on its native `#24292e`).
- An `@theme inline` bridge exposing tokens as utilities (`text-ink`, `bg-paper`, `border-rule`, `bg-accent-soft`, …) that flip automatically.

**Commit 2 — migration + docs:**
- 34 files moved off stock `gray-*`/`blue-*` chrome to the token utilities; redundant `dark:` variants removed (tokens flip on their own). `text-white` on accent buttons → `text-accent-fg` (white fails contrast on the lightened dark accent). Card/input/tooltip `bg-white` → `bg-paper`.
- **Left untouched by design:** the SkillBar/RadarChart categorical data palettes and success-green/error-red status colours — these encode data, not brand.
- Tests that pinned migrated class names updated to the token classes.
- Rewrote `CLAUDE.md` and `.debug/000-quick-reference.md`, which still described a Pages Router + `next-translate` + webpack project that hasn't existed since `474b44c`.

## Verification (Node 24)

| Gate | Result |
|---|---|
| `npm run lint` | 0 errors (same 4 pre-existing warnings) |
| `npm run test` | 298/298 pass |
| `npm run build` | exit 0, 132 pages |

In-browser, both schemes confirmed via computed styles: shiki emits github-light (`rgb(215,58,73)` keyword) in light and github-dark (`rgb(249,117,131)`) in dark, each on a transparent-on-paper block; migrated components resolve to the flipped tokens in dark (RadarChart labels `--ink-soft`, SkillBar track `--bg-alt`, dates `--ink-muted`); no console errors. Screenshot below is the Stack page in dark mode — note the RadarChart's data-blue is deliberately preserved.

**Note:** `CLAUDE.md` in the parent projects directory (`/Users/alienard/Code/CLAUDE.md`) had the same stale description and I fixed it locally, but it lives outside this repo so it is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
